### PR TITLE
Fix/allow bracketed string

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "daifukuninja",
   "displayName": "URL to Linkcard for Zenn markdown",
   "description": "%extension.description%",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "engines": {
     "vscode": "^1.77.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,14 @@
 'use strict';
 import * as vscode from 'vscode';
-import { validateUrl } from './is-url';
+import { unbracketString, validateUrl } from './is-url';
 import { localeMap } from './localeMap';
+import isUrl from 'is-url';
 
 const SUPPORTED_DOC_ID = [
 	"markdown"	// support for markdown only
 ];
 
-const showInfomationAndExit = (message:string) => {
+const showInfomationAndExit = (message: string) => {
 	vscode.window.showInformationMessage(message);
 	return;
 };
@@ -17,7 +18,8 @@ export function activate(context: vscode.ExtensionContext) {
 	let fromClipboard = vscode.commands.registerCommand('zenn-url-to-linkcard.fromClipboard', () => {
 		const promise = vscode.env.clipboard.readText();
 		promise.then((text) => {
-			if (!validateUrl(text)) {
+			const unbracketed: string = unbracketString(text);
+			if (!isUrl(unbracketed)) {
 				return showInfomationAndExit(localeMap("showInformationMessage.selectionTextIsNotUrl"));
 			}
 			const editor = vscode.window.activeTextEditor;
@@ -30,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 			// text is Url
 			editor.edit(builder => {
-				builder.insert(editor.selection.active, `@[card](${text})\n`);
+				builder.insert(editor.selection.active, `@[card](${unbracketed})\n`);
 			});
 		});
 	});
@@ -38,19 +40,20 @@ export function activate(context: vscode.ExtensionContext) {
 	let fromSelection = vscode.commands.registerCommand('zenn-url-to-linkcard.fromSelection', () => {
 		const editor = vscode.window.activeTextEditor;
 		if (editor == null) {
-			 return;
+			return;
 		}
 		const doc = editor.document;
 		if (doc == null) {
 			return;
 		}
 		const text = doc.getText(editor.selection).trim();
-		if (!validateUrl(text)) {
+		const unbracketed: string = unbracketString(text);
+		if (!isUrl(unbracketed)) {
 			return showInfomationAndExit(localeMap("showInformationMessage.selectionTextIsNotUrl"));
 		}
 		// text is Url
 		editor.edit(builder => {
-			builder.replace(editor.selection, `@[card](${text})\n`);
+			builder.replace(editor.selection, `@[card](${unbracketed})\n`);
 		});
 	});
 

--- a/src/is-url.ts
+++ b/src/is-url.ts
@@ -2,10 +2,15 @@ import isUrl = require('is-url');
 
 // validate text is Url string
 // or angle bracketed Url string 
-export const validateUrl = (text:string) => {
+export const validateUrl = (text:string): boolean => {
 	// If it suspect angle bracketed, remove 1 character before and after
-	if (text.startsWith("<") && text.endsWith(">")) {
-		text = text.slice(2).slice(0, -1);
-	}
-	return isUrl(text);
+	const unbracketed = unbracketString(text);
+	return isUrl(unbracketed);
 };
+
+export const unbracketString = (text:string): string => {
+	if (text.startsWith("<") && text.endsWith(">")) {
+		text = text.slice(1).slice(0, -1);
+	}
+	return text;
+}

--- a/src/test/is-url.test.ts
+++ b/src/test/is-url.test.ts
@@ -1,4 +1,4 @@
-import { validateUrl } from '../is-url';
+import { unbracketString, validateUrl } from '../is-url';
 
 describe('is-url', () => {
   it('check url strings to be true', () => {
@@ -12,5 +12,13 @@ describe('is-url', () => {
   });
   it('check not url strings to be false', () => {
     expect(validateUrl("テスト")).toBe(false);
+  });
+  it('check bracked url issue', () => {
+    expect(unbracketString("<https://zenn.dev/>")).toBe("https://zenn.dev/");
+    expect(unbracketString("https://zenn.dev/")).toBe("https://zenn.dev/");
+  });
+  it('check incomplete bracked url issue', () => {
+    expect(unbracketString("https://zenn.dev/>")).toBe("https://zenn.dev/>");
+    expect(unbracketString("<https://zenn.dev/")).toBe("<https://zenn.dev/");
   });
 });


### PR DESCRIPTION
"<>"に囲まれたURLを処理した際に、"<>"を含めたままでリンクカードにしてしまう問題の修正
`v1.0.0`に更新